### PR TITLE
Fix header line 'Can Typora work without Pandoc' by removing whitespace

### DIFF
--- a/_posts/2016-05-02-Install and Use Pandoc.md
+++ b/_posts/2016-05-02-Install and Use Pandoc.md
@@ -65,7 +65,7 @@ After Pandoc is installed, then you could import supported file types by clickin
 
 Versions ≥ 1.16 is required. The latest version, the better. So updating Pandoc is encouraged if your Pandoc version is too old.
 
- #### Can Typora work without Pandoc ?
+#### Can Typora work without Pandoc ?
 
 Yes, only import and export (other than HTML/PDF file types) needs it.
 


### PR DESCRIPTION
Although the file seems to display correctly on GitHub Markdown preview, it displayed as '###' on the website. This PR will remove the whitespace and fix it. 