### PR TITLE
Exclude code blocks from the RTL effect

### DIFF
--- a/_posts/2017-08-23-RTL.md
+++ b/_posts/2017-08-23-RTL.md
@@ -19,4 +19,9 @@ Add following Custom CSS:
     direction: rtl;
 }
 ```
-
+To exclude code blocks from the RTL effect add the following Custom CSS:
+```css
+[class^="Code"] {
+    direction: ltr;
+}
+```

--- a/_posts/2017-08-23-RTL.md
+++ b/_posts/2017-08-23-RTL.md
@@ -21,7 +21,7 @@ Add following Custom CSS:
 ```
 To exclude code blocks from the RTL effect add the following Custom CSS:
 ```css
-[class^="Code"] {
+[class^="code"] {
     direction: ltr;
 }
 ```

--- a/_posts/2017-08-23-RTL.md
+++ b/_posts/2017-08-23-RTL.md
@@ -21,7 +21,7 @@ Add following Custom CSS:
 ```
 To exclude code blocks from the RTL effect add the following Custom CSS:
 ```css
-[class^="Code"] {
+pre, code {
     direction: ltr;
 }
 ```

--- a/_posts/2017-08-23-RTL.md
+++ b/_posts/2017-08-23-RTL.md
@@ -21,7 +21,7 @@ Add following Custom CSS:
 ```
 To exclude code blocks from the RTL effect add the following Custom CSS:
 ```css
-[class^="code"] {
+[class^="Code"] {
     direction: ltr;
 }
 ```


### PR DESCRIPTION
Usually, code blocks are written in English and they need to be LTR.
This CSS will solve this issue.