### PR TITLE
update link to mermaid

### DIFF
--- a/_posts/2016-08-15-Draw Diagrams With Markdown.md
+++ b/_posts/2016-08-15-Draw Diagrams With Markdown.md
@@ -48,7 +48,7 @@ cond(no)->op
 
 # Mermaid
 
-Typora also has integration with [mermaid](https://knsv.github.io/mermaid/#/), which supports sequence diagrams, flowcharts, Gantt charts, class and state diagrams, and pie charts. 
+Typora also has integration with [mermaid](https://mermaid-js.github.io/mermaid/#/), which supports sequence diagrams, flowcharts, Gantt charts, class and state diagrams, and pie charts. 
 
 ## Sequence Diagrams
 


### PR DESCRIPTION
The development of project [mermaid](https://github.com/mermaid-js/mermaid) is now under organization [mermaid-js](https://github.com/mermaid-js). This makes the old link https://knsv.github.io/mermaid/#/ invalid.

(Not sure if I have opened a similar pr before. Feel free to close it if this problem is already reported or a similar fixing is already in progress.)