### PR TITLE
Change name attribute to id in named anchor example.

### DIFF
--- a/_posts/2018-03-18-Links.md
+++ b/_posts/2018-03-18-Links.md
@@ -109,7 +109,7 @@ A [link](#this-is-a-title) to jump towards target header
 You could also write **named** anchors using raw HTML:
 
 ```html
-<a name="anchor"></a> Anchor
+<a id="anchor"></a> Anchor
 
 <a href="#anchor">Link to Anchor</a>
 ```


### PR DESCRIPTION
The name attribute in an anchor element is deprecated. Use of id is preferred.