### PR TITLE
Fix the backquote escape problem

### DIFF
--- a/_posts/2016-01-01-Markdown Reference.md
+++ b/_posts/2016-01-01-Markdown Reference.md
@@ -36,7 +36,7 @@ Headers use 1-6 hash (`#`) characters at the start of the line, corresponding to
 ###### This is an H6
 ```
 
-In Typora, input ‘#’s followed by title content, and press `Return` key will create a header. Or type ⌘1 to ⌘6 as a shortcut.
+In Typora, input `#` followed by title content, and press `Return` key will create a header. Or type ⌘1 to ⌘6 as a shortcut.
 
 ### Blockquotes
 
@@ -52,7 +52,7 @@ Markdown uses email-style > characters for block quoting. They are presented as:
 > This is another blockquote with one paragraph. There is three empty line to seperate two blockquote.
 ```
 
-In Typora, typing ‘>’ followed by your quote contents will generate a quote block. Typora will insert a proper ‘>’ or line break for you. Nested block quotes (a block quote inside another block quote) by adding additional levels of ‘>’.
+In Typora, typing `>` followed by your quote contents will generate a quote block. Typora will insert a proper `>` or line break for you. Nested block quotes (a block quote inside another block quote) by adding additional levels of `>`.
 
 ### Lists
 
@@ -92,7 +92,7 @@ You can change the complete/incomplete state by clicking on the checkbox before 
 
 Typora only supports fences in GitHub Flavored Markdown, not the original code block style.
 
-Using fences is easy: type  \`\`\` and press `return`. Add an optional language identifier after \`\`\` and Typora runs it through syntax highlighting:
+Using fences is easy: type ` ``` ` and press `Return`. Add an optional language identifier after ` ``` ` and Typora runs it through syntax highlighting:
 
 ``` markdown
 Here's an example:
@@ -192,7 +192,7 @@ You can create footnotes like this[^fn1] and this[^fn2].
 [^fn2]: Here is the *text* of the second **footnote**.
 ```
 
-Hover over the ‘fn1’ or 'fn2' superscript to see content of the footnote. You can use whatever unique identified you like as the footnote marker (e.g. "fn1").
+Hover over the `fn1` or `fn2` superscript to see content of the footnote. You can use whatever unique identified you like as the footnote marker (e.g. "fn1").
 
 Hover over the footnote superscripts to see content of the footnote.
 


### PR DESCRIPTION
- According to [commonmark](https://spec.commonmark.org/0.29)'s instructions, backslash escapes do not work in code blocks, code spans, autolinks, or raw HTML.
- Backslash escapes are never needed, because one can always choose a string of n backtick characters as delimiters, where the code does not contain any strings of exactly n backtick characters.
- This allows you to include code that begins or ends with backtick characters, which must be separated by whitespace from the opening or closing backtick strings.