### PR TITLE
Fix [ _posts content ] : typos in _posts up to initial release

### DIFF
--- a/_posts/2016-01-01-Markdown Reference.md
+++ b/_posts/2016-01-01-Markdown Reference.md
@@ -47,11 +47,11 @@ Markdown uses email-style > characters for block quoting. They are presented as:
 ``` markdown
 > This is a blockquote with two paragraphs. This is first paragraph.
 >
-> This is second pragraph. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+> This is second paragraph. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 
 
 
-> This is another blockquote with one paragraph. There is three empty line to seperate two blockquote.
+> This is another blockquote with one paragraph. There is three empty line to separate two blockquotes.
 ```
 
 In Typora, typing ‘>’ followed by your quote contents will generate a quote block. Typora will insert a proper ‘>’ or line break for you. Nested block quotes (a block quote inside another block quote) by adding additional levels of ‘>’.

--- a/_posts/2016-05-02-Install and Use Pandoc.md
+++ b/_posts/2016-05-02-Install and Use Pandoc.md
@@ -9,7 +9,7 @@ typora-root-url: ../
 
 TL;DR:
 
-Typora requires [Pandoc](http://pandoc.org/) for some of its advanced features. If you don't have Pandoc (or have a version older than v2.0), please download and run the installer from **[Pandoc Dsownload Page](https://github.com/jgm/pandoc/releases/latest)**.
+Typora requires [Pandoc](http://pandoc.org/) for some of its advanced features. If you don't have Pandoc (or have a version older than v2.0), please download and run the installer from **[Pandoc Download Page](https://github.com/jgm/pandoc/releases/latest)**.
 
 You may need to restart Typora after install Pandoc if you receive an error that Typora cannot find Pandoc.
 
@@ -55,7 +55,7 @@ Download the `pandoc-*-window.msi` from Pandoc's [download page](https://github
 
 ## Config Pandoc Path
 
-If Typora still shows "Require Pandoc to Continue" even after installed pandoc, please try restart Typora. If typora still cannot find pandoc after restart, you can manunlly input pandoc path on `Preferences Panel` → `Export` → `General`.
+If Typora still shows "Require Pandoc to Continue" even after installed pandoc, please try restart Typora. If typora still cannot find pandoc after restart, you can manually input pandoc path on `Preferences Panel` → `Export` → `General`.
 
 ![pandoc path](/media/export/Screen%20Shot%202021-01-18%20at%2022.51.30.png)
 
@@ -92,7 +92,7 @@ Exporting by Typora is also powered by Pandoc, yet Typora will not convert direc
 
 #### Can all block/inline element types be exported correctly?
 
-Exporting Task lists are not supported yet. Underline and highlight for `.docx` is supported only if they are not used inside or outside other inline styles. Underlining and highlights are not support for OpenOffice(`.odt`). Embeddeding .gif files is not support for LaTeX. Other block or inline elements can be exported, but the styles cannot be 100% matched when imported or exported.
+Exporting Task lists are not supported yet. Underline and highlight for `.docx` is supported only if they are not used inside or outside other inline styles. Underlining and highlights are not support for OpenOffice(`.odt`). Embedding .gif files is not support for LaTeX. Other block or inline elements can be exported, but the styles cannot be 100% matched when imported or exported.
 
 #### How to uninstall Pandoc for mac?
 

--- a/_posts/2016-06-22-Custom Font.md
+++ b/_posts/2016-06-22-Custom Font.md
@@ -70,7 +70,7 @@ This option requires support from the theme(s) you use. If you are making a them
 
 <img alt="2" src="/media/custom-font/2.png" style="zoom:50%" />
 
-## Change Font for Souce Code Mode
+## Change Font for Source Code Mode
 
 You can use 
 

--- a/_posts/2016-06-24-Backgound.md
+++ b/_posts/2016-06-24-Backgound.md
@@ -61,7 +61,7 @@ body {
   background-color: #8F9D9A;
 }
 
-/**Other CSS to adjuest UI components*/
+/**Other CSS to adjust UI components*/
 ```
 
 Produces:

--- a/_posts/2016-06-26-Use Typora From Shell or cmd.md
+++ b/_posts/2016-06-26-Use Typora From Shell or cmd.md
@@ -28,7 +28,7 @@ To set Typora as the default markdown editor:
 
 1. Select one of your markdown files
 2. Open context menu and choose
-    - _Properties_ and then click on _Change_ buttong, as shown in **Figure 1**
+    - _Properties_ and then click on _Change_ button, as shown in **Figure 1**
     - _Open with -> Choose another app_, as shown in **Figure 2**
 3. Choose _Typora_ or _Typora Launcher_ in **How do you want to open this file?** and set a checkmark for _Always use this app to open .md files._
 
@@ -38,7 +38,7 @@ To set Typora as the default markdown editor:
 
 
 **Figure 2 - Application chooser window**  
-![Figure 2 - Applicaiton chooser](/media/use-from-shell/Snip20180704_2.png)  
+![Figure 2 - Application chooser](/media/use-from-shell/Snip20180704_2.png)  
 
 ## Linux
 

--- a/_posts/2016-09-26-About Themes.md
+++ b/_posts/2016-09-26-About Themes.md
@@ -15,7 +15,7 @@ Typora uses CSS to style everything. Each theme shown in the Themes menu is one 
 
 ## Use Themes Under Light Mode and Dark Mode
 
-You can set separate themes for light mode and dark mode (on macOS / Windows). When the system’s color scheme changed, the corresponvsinf theme you chose will be applied.
+You can set separate themes for light mode and dark mode (on macOS / Windows). When the system’s color scheme changed, the corresponding theme you chose will be applied.
 
 <img src="/media/new-97/Screen Shot 2020-12-05 at 17.01.49.png" alt="Screen Shot 2020-12-05 at 17.01.49" style="zoom:50%;" />
 

--- a/_posts/2016-09-26-Typora on Linux.md
+++ b/_posts/2016-09-26-Typora on Linux.md
@@ -47,7 +47,7 @@ But if you’re not OK with the warning, you can do followings:
 3. Paste repo definition into this file:
 
    ```shell
-   deb [arch=amd64 signed-by=/usr/share/keyrings/typora.gpg] htps://typora.io/linux ./
+   deb [arch=amd64 signed-by=/usr/share/keyrings/typora.gpg] https://typora.io/linux ./
    ```
 
 4. Now you can install Typora:
@@ -69,7 +69,7 @@ sudo apt-get upgrade
 ## NixOS
 
 ```bash
-# install typora to the curent user's profile
+# install typora to the current user's profile
 nix-env -i typora
 ```
 
@@ -92,8 +92,8 @@ sudo apt-get install typora
 
 You can also manually download and install the deb package file, following those steps:
 
-1. The `deb` file is located at `https://typora.io/linux/typora_${version}_amd64.deb`, for example: `https://typora.io/linux/typora_0.9.96_amd64.deb`. Just downlad the deb installer at that url.
-2. Double click the deb file to start intsall on Ubuntu / Debian.
+1. The `deb` file is located at `https://typora.io/linux/typora_${version}_amd64.deb`, for example: `https://typora.io/linux/typora_0.9.96_amd64.deb`. Just download the deb installer at that url.
+2. Double click the deb file to start installing on Ubuntu / Debian.
 
 ## Other Distributions
 
@@ -160,7 +160,7 @@ Try install `libgconf-2-4` first.
 
 #### NSS out-of-date
 
-If you recieve following error when launching Typora:
+If you receive following error when launching Typora:
 
 ```
 [7465:7499:0911/174740.042852:FATAL:nss_util.cc(632)] NSS_VersionCheck("3.26") failed. NSS >= 3.26 is required. Please upgrade to the latest NSS, and if you still get this error, contact your distribution maintainer.

--- a/_posts/2016-11-11-Images.md
+++ b/_posts/2016-11-11-Images.md
@@ -62,7 +62,7 @@ If you enable `Editor` → `Image Insert` →  `Use relative path if possible` i
 
 ### Use Escaped Path
 
-Both links and image sources (`src`) support original unescpaed path for better readibility, for example `![image](./Name 名字.png)` can be read by Typora successfult if image file exists in that path. However, some markdown engine or broswer does not support unescpaed path. By enabling `Editor` → `Image Insert` → `Auto escape image URL when insert` in preferences panel, the path will be converted into escaped ones: `![image](Name%20%u540D%u5B57.png)`.
+Both links and image sources (`src`) support original unescaped path for better readability, for example `![image](./Name 名字.png)` can be read by Typora successfully if image file exists in that path. However, some markdown engine or browser does not support unescaped path. By enabling `Editor` → `Image Insert` → `Auto escape image URL when insert` in preferences panel, the path will be converted into escaped ones: `![image](Name%20%u540D%u5B57.png)`.
 
 ### Copy image files to target folder when inserting local image
 

--- a/_posts/2017-08-24-Auto Pair.md
+++ b/_posts/2017-08-24-Auto Pair.md
@@ -19,10 +19,8 @@ Open preference panel, and enable "Auto pair brackets and quotes" (item 1 in ima
 
 ## Auto Pair for Extended Chars
 
-If "Auto pair common markdown syntax" is enabled, the auto pair behavior will also be extended to markdown symbols, like `*`, `~`, <code>\`</code>, or `_`, if "hightlight", "inline math", "superscript" is enabled, then  auto pair for `=`,  `$` and `^` will also be turned on. 
+If "Auto pair common markdown syntax" is enabled, the auto pair behavior will also be extended to markdown symbols, like `*`, `~`, <code>\`</code>, or `_`, if "highlight", "inline math", "superscript" is enabled, then  auto pair for `=`,  `$` and `^` will also be turned on. 
 
 Please note that, for `~`, `=` and `^` , the ending pair will not be inserted automatically, but when you select a word, and input characters like `=`, then the word will be surrounded by `=` automatically.
 
 <video autoplay="" muted="muted" preload="preload" loop="loop" src="/media/auto-pairs/autopair2.webm" type="video/webm" style="zoom:50%"></video>
-
-

--- a/_posts/2018-03-18-Links.md
+++ b/_posts/2018-03-18-Links.md
@@ -21,7 +21,7 @@ typora-root-url: ../
 [Link Text](link-address "optional title")
 ```
 
-Protocols like `http://` cannot be ommited for this type of syntax.
+Protocols like `http://` cannot be omitted for this type of syntax.
 
 #### Reference Link
 
@@ -39,7 +39,7 @@ or, it can be shorten as
 [Ref]: link-address
 ```
 
-Protocols like `http://` cannot be ommited for this type of syntax.
+Protocols like `http://` cannot be omitted for this type of syntax.
 
 #### Autolink
 
@@ -69,7 +69,7 @@ You could also use raw HTML to add links, for example
 
 ---
 
-For link towards a website, we suggest you **DO NOT ommit URL protocols** like `https://` or `http://`, or it may be interpreted as relative link by Typora or other Markdown egines, or after  export/publish. 
+For link towards a website, we suggest you **DO NOT omit URL protocols** like `https://` or `http://`, or it may be interpreted as relative link by Typora or other Markdown engines, or after  export/publish. 
 
 ## Link to Local Files
 
@@ -161,5 +161,5 @@ If you want to make a link to local file `abd.com`, please make ensure the path 
 
 If you want to create a link towards website "abc.com", you need to put the URL scheme or protocol, for example use `[link](http://abc.com)`. 
 
-Sometimes, protocol can be omitted if you use autolink (`<www.google.com>`) or auto URL (`www.google.com`), but this rules variables across different Markdown editors/engines, so we will recommend you NOT ommit protocols in any case for less compatibility issue.
+Sometimes, protocol can be omitted if you use autolink (`<www.google.com>`) or auto URL (`www.google.com`), but this rules variables across different Markdown editors/engines, so we will recommend you NOT omit protocols in any case for less compatibility issue.
 

--- a/_posts/2018-05-26-SmartyPants.md
+++ b/_posts/2018-05-26-SmartyPants.md
@@ -44,23 +44,23 @@ You can find the option `Smart Dashes` from menu bar or from preferences panel. 
 
 ## Escape quotes and dashes
 
-You could use `\"` and `\-` to escape quotes and dashes to prevent them from beging converted.
+You could use `\"` and `\-` to escape quotes and dashes to prevent them from being converted.
 
 ## "Convert on Input" and "Convert on Rendering"
 
 Those options controls how punctuations are converted.
 
-When **Convert on Input** is enabled, quotes and dashes are converted *immediately* when user is typing, and **converted one will be saved in the Markdown source code**.  If example, if smart dashes are enabled, and after user input `...`, he will got `… ` in both edit/preview view and source code. And user can cancel the inproper convert by `undo` operation.
+When **Convert on Input** is enabled, quotes and dashes are converted *immediately* when user is typing, and **converted one will be saved in the Markdown source code**.  As example, if smart dashes are enabled, and after user input `...`, he will get `… ` in both edit/preview tab and source code. And user can cancel the improper convert by `undo` operation.
 
-When **Convert on Rendering** is enabled, when user input ASCII quotes and dashes, **the original ASCII will be saved in the source mode**, but in edit/preview view, Typora will render them as curly quotes or unicode dashes.  
+When **Convert on Rendering** is enabled, typing in ASCII quotes and dashes **will save the original ASCII code on source mode**, but in edit/preview tab, Typora will render them as curly quotes or unicode dashes.  
 
-The both ignore the convertion when user input in YAML/code/math blocks or in source code mode.
+Both ignore convertion when user input in YAML/code/math blocks or in source code mode.
 
 ## Remap Unicode Punctuation on Parse
 
 When smart dashes are enabled for "Convert on Input", if user input `<!-- comment -->` it will become `<!— comments —> ` since `--` are converted. 
 
-To prevent such sutuation, Typora introduce this option. When it is enabled, Typora will remap unicode alternatives of markdown syntax as their ASCII one, e.g:
+To prevent such situation, Typora introduce this option. When it is enabled, Typora will remap unicode alternatives of markdown syntax as their ASCII one, e.g:
 
 | Input                                              | Parsed as                 |
 | -------------------------------------------------- | ------------------------- |
@@ -79,4 +79,4 @@ When **Convert on Input** is enabled, this option will also be enabled automatic
 Typora does **not** support further text replacement rules (e.g: `->` to `→`, or `(C)` to `©`) out of the box. To do this:
 
 - On macOS, we recommend you to do settings in `System Preferences` → `Keyboard` → `Text`. And enable "Text Replacement" in Typora's menu. Then Typora can use your text replacement rules.
-- On Windows/Linux, we recommand you to use 3rd party apps for the configuration of text replacement. You could choose from [this list](https://alternativeto.net/software/textexpander/).
+- On Windows/Linux, we recommend you to use 3rd party apps for the configuration of text replacement. You could choose from [this list](https://alternativeto.net/software/textexpander/).

--- a/_posts/2018-08-14-Math.md
+++ b/_posts/2018-08-14-Math.md
@@ -109,7 +109,7 @@ When Math rendering goes wrong, like output math too wild/narrow, or equation nu
 
 ### Line Breaking
 
-Starting from v0.11.0, Typora upgraded to MathJax v3, which does not support line break using `\\` or `\newline` in MathJax v2, the behavior is same with LaTeX, unless you put them in a `\displaylines{}` enviroment, for example:
+Starting from v0.11.0, Typora upgraded to MathJax v3, which does not support line break using `\\` or `\newline` in MathJax v2, the behavior is same with LaTeX, unless you put them in a `\displaylines{}` environment, for example:
 
 ```
 \displaylines{x+y\\y+z}

--- a/_posts/2018-10-22-Spellcheck.md
+++ b/_posts/2018-10-22-Spellcheck.md
@@ -55,9 +55,9 @@ Click “Install dictionary file only for Typora“ from the pulldown button whe
 
 ### Linux and older Windows
 
-Click “Install language Support“ when error notification of spellcheck is shown, Typora will display the license info of the dictionary file, and then after click “download“ button, typora will download the dictionary file. You could see the download progress from the status bar.
+Click “Install language Support“ when error notification of spellcheck is shown, Typora will display the license info of the dictionary file, and then after click “download“ button, Typora will download the dictionary file. You could see the download progress from the status bar.
 
-You could download needed language manually from <https://dict.typora.io/>, and put them under folder `{typora-user-folder}\dictionaries`, you could find the location of `{typora-user-folder}` by opening “theme folder“ from preferences panels, and then open its parent folder. On Linux it looks like `~/.config/Typora`, and on Windows it looks like `C:/user/{yout-user-name}/appData/Roaming/Typora`.
+You could download needed language manually from <https://dict.typora.io/>, and put them under folder `{typora-user-folder}\dictionaries`, you could find the location of `{typora-user-folder}` by opening “theme folder“ from preferences panels, and then open its parent folder. On Linux it looks like `~/.config/Typora`, and on Windows it looks like `C:/user/{your-user-name}/appData/Roaming/Typora`.
 
 #### License info
 

--- a/_posts/2018-12-30-Dark Mode.md
+++ b/_posts/2018-12-30-Dark Mode.md
@@ -16,7 +16,7 @@ typora-root-url: ../
 
 <img src="/media/windows/Screenshot 2020-12-08 234125.png" alt="Screenshot 2020-12-08 234125" style="zoom:38%;" />
 
-You can set separate themes for light mode and dark mode. When the system’s color scheme changed, the corresponvsinf theme you chose will be applied.
+You can set separate themes for light mode and dark mode. When the system’s color scheme changed, the corresponding theme you chose will be applied.
 
 <img src="/media/new-97/Screen Shot 2020-12-05 at 17.01.49.png" alt="Screen Shot 2020-12-05 at 17.01.49" style="zoom:50%;" />
 

--- a/_posts/2019-01-05-Shortcut Keys.md
+++ b/_posts/2019-01-05-Shortcut Keys.md
@@ -57,7 +57,7 @@ On macOS, you can press `Esc` key to open inline preview for inline math, auto-c
 | Delete Word                                     | Ctrl + Shift + D           | Command + Shift + D                 |
 | Jump to Top                                     | Ctrl + Home                | Command + ↑                         |
 | Jump to Selection                               | Ctrl + J                   | Command + J                         |
-| Jump to Buttom                                  | Ctrl + End                 | Command + ↓                         |
+| Jump to Bottom                                  | Ctrl + End                 | Command + ↓                         |
 | Find                                            | Ctrl + F                   | Command + F                         |
 | Find Next                                       | F3 / Enter                 | Command + G / Enter                 |
 | Find Previous                                   | Shift + F3 / Shift + Enter | Command + Shift + G / Shift + Enter |
@@ -104,7 +104,7 @@ On macOS, you can press `Esc` key to open inline preview for inline math, auto-c
 | Source Code Mode                | Ctrl + /               | Command + /           |
 | Focus Mode                      | F8                     | F8                    |
 | Typewriter Mode                 | F9                     | F9                    |
-| Toggler Fullscreen              | F11                    | Command + Option + F  |
+| Toggle Fullscreen               | F11                    | Command + Option + F  |
 | Actual Size                     | Ctrl + Shift + 0       | *(Not Supported)*     |
 | Zoom In                         | Ctrl + Shift + =       | *(Not Supported)*     |
 | Zoom Out                        | Ctrl + Shift + -       | *(Not Supported)*     |

--- a/_posts/2019-01-08-What's New-0.9.61.md
+++ b/_posts/2019-01-08-What's New-0.9.61.md
@@ -40,7 +40,7 @@ We added:
 
 ## Word Count
 
-Read more details in [Word Cound](/Word-Count).
+Read more details in [Word Count](/Word-Count).
 
 ### Choose default counting statistics
 

--- a/_posts/2019-03-11-What's New-0.9.66.md
+++ b/_posts/2019-03-11-What's New-0.9.66.md
@@ -28,7 +28,7 @@ Typora is using [Electron](https://electronjs.org/) as framework to run on Linux
 
 ### Security
 
-- Fix potation XSS issue for export, math, and iframe.
+- Fix rotation XSS issue for export, math, and iframe.
 
 ### Others
 

--- a/_posts/2019-08-03-What's New-0.9.73.md
+++ b/_posts/2019-08-03-What's New-0.9.73.md
@@ -81,13 +81,13 @@ The older update logic won't quit Typora before run the updater.exe. Therefore, 
 
 ## Notes for macOS ≤ 10.12
 
-**TLBR**: Typora v0.9.9.27 requires macOS ≥ 10.13, and we released a compatible version v0.9.9.26 for 10.12 ~ 10.11. We will reduce the update rate for the "older compatible" version. Support for 10.10 is ended. 
+**TLDR**: Typora v0.9.9.27 requires macOS ≥ 10.13, and we released a compatible version v0.9.9.26 for 10.12 ~ 10.11. We will reduce the update rate for the "older compatible" version. Support for 10.10 is ended. 
 
 But you can still download and use the older versions for those platform [here](https://support.typora.io/Older-macOS-Support/).
 
 **Explanation**:
 
-We were doing refactors in recent updates for this change, and now, in this update, we finally switched from `Webview` to `WKWebview` for our main rendering view. Apple claims that `WKWebview` have  better performance, but in our test, the speed and memory usage are almost same for `WKWebview` and the legacy `Webview`. So the main reason for this change is that Apple marks `Webview` as deprecated, and some new features, such as `prefers-dark-interface`, is not ported to the old `Webview`, while `WKWebview` will be more active maintained in future. Also, `WKWebiew` have better support for IME.
+We were doing refactors in recent updates for this change, and now, in this update, we finally switched from `Webview` to `WKWebview` for our main rendering view. Apple claims that `WKWebview` have  better performance, but in our test, the speed and memory usage are almost same for `WKWebview` and the legacy `Webview`. So the main reason for this change is that Apple marks `Webview` as deprecated, and some new features, such as `prefers-dark-interface`, is not ported to the old `Webview`, while `WKWebview` will be more active maintained in future. Also, `WKWebview` have better support for IME.
 
 `WKWebview`, however, has more limitation and less APIs than `Webview`. Although Apple is improving that, for macOS ≤ 10.12, still some necessary APIs (even private alternatives) are missing, so the "compatible" build will still use the legacy `Webview`.
 

--- a/_posts/2019-11-05-Trouble Shooting.md
+++ b/_posts/2019-11-05-Trouble Shooting.md
@@ -15,7 +15,7 @@ Please enable related features in preferences panel.
 
 #### How to downgrade
 
-You cuold find History builds here:
+You can find old release builds here:
 
 - macOS: https://typora.io/dev_release.html
 - Linux / Windows: https://typora.io/windows/dev_release.html

--- a/_posts/2019-11-30-What's New-0.9.80.md
+++ b/_posts/2019-11-30-What's New-0.9.80.md
@@ -42,7 +42,7 @@ classDiagram
       }
 ```
 
-<img src="/media/new-80/Screen Shot 2019-11-27 at 23.17.54.png" alt="Screen Shot 2019-11-27 at 23.17.54" style="zoom:50%;" />
+<img src="/media/new-80/class-diagram.png" alt="class-diagram" style="zoom:50%;" />
 
 ##### [State Diagram](https://mermaidjs.github.io/#/stateDiagram)
 
@@ -57,7 +57,7 @@ stateDiagram
     Crash --> [*]
 ```
 
-<img src="/media/new-80/Screen Shot 2019-11-27 at 23.18.55.png" alt="Screen Shot 2019-11-27 at 23.18.55" style="zoom:50%;" />
+<img src="/media/new-80/state-diagram.png" alt="state-diagram" style="zoom:50%;" />
 
 ##### [Pie Chart Diagrams](https://mermaidjs.github.io/#/pie?id=pie-chart-diagrams)
 
@@ -68,7 +68,7 @@ pie
     "Rats" : 150 
 ```
 
-<img src="/media/new-80/Screen Shot 2019-11-27 at 23.19.11.png" alt="Screen Shot 2019-11-27 at 23.19.11" style="zoom:50%;" />
+<img src="/media/new-80/pie-chart.png" alt="pie-chart" style="zoom:50%;" />
 
 Besides the new diagrams, there are also a few bug fix:
 

--- a/_posts/2020-02-22-Upload Image.md
+++ b/_posts/2020-02-22-Upload Image.md
@@ -15,7 +15,7 @@ typora-root-url: ../
 
 In newer version of Typora (≥ 0.9.9.32 on macOS or 0.9.84  on Windows / Linux), we added a “upload image” function to upload images to a cloud image storage via 3rd apps or scripts.
 
-Its motivation is that, since markdown files is just plain text files, when you embed images, the markdown files does not “own” those images, but just keep a weak reference to used external image files. When you move or share markdown files, those images should also be moved or shared, which brings maintaince costs. But if those images are hosted online, you can move or share markdown files freely without maintaining the reference between text plain and the images it used.
+Its motivation is that, since markdown files is just plain text files, when you embed images, the markdown files does not “own” those images, but just keep a weak reference to used external image files. When you move or share markdown files, those images should also be moved or shared, which brings maintenance costs. But if those images are hosted online, you can move or share markdown files freely without maintaining the reference between text plain and the images it used.
 
 Typora now supports apps like iPic, uPic, PicGo, etc, which is able to upload your images into [Imgur](http://imgur.com/), [Flickr](https://www.flickr.com/),[ Amazon S3](https://aws.amazon.com/s3/), [Github](www.github.com), or other image hosting services.
 
@@ -61,7 +61,7 @@ If it shows "Validation Failed", you need to check the reason from the raw outpu
 
 ![ipic](/media/image-upload/ipic.jpg)
 
-[iPic][ttps://itunes.apple.com/app/id1101244278] is a **freemium** app which allows you to upload local images into various cloud service, including [Imgur](http://imgur.com/), [Flickr](https://www.flickr.com/),[ Amazon S3](https://aws.amazon.com/s3/), etc, and return you a web url of the uploaded image for public access. 
+[iPic][https://itunes.apple.com/app/id1101244278] is a **freemium** app which allows you to upload local images into various cloud service, including [Imgur](http://imgur.com/), [Flickr](https://www.flickr.com/),[ Amazon S3](https://aws.amazon.com/s3/), etc, and return you a web url of the uploaded image for public access. 
 
 [Download](https://itunes.apple.com/app/id1101244278)
 

--- a/_posts/2020-02-22-What's New-0.9.84.md
+++ b/_posts/2020-02-22-What's New-0.9.84.md
@@ -25,7 +25,7 @@ For details, please [check here](/Upload-Image).
 
 ### Footnote Quick Jump
 
-For the [footnote](/Markdown-Reference/#footnotes) syntax, we will append an <a href="#">↩</a> link after its definition when it is used. And user will jump to its references by clicking the link. Also for the reference of footnote (like `[^footnote]`), user can jump it is definition quickly by clicking it when pressing `ctrl` or `commmand` (macOS) key.
+For the [footnote](/Markdown-Reference/#footnotes) syntax, we will append an <a href="#">↩</a> link after its definition when it is used. And user will jump to its references by clicking the link. Also for the reference of footnote (like `[^footnote]`), user can jump it is definition quickly by clicking it when pressing `ctrl` or `command` (macOS) key.
 
 <img src="/media/new-84/2020-02-23 18-04-19.2020-02-23 18_05_49.gif" alt="2020-02-23 18-04-19.2020-02-23 18_05_49" style="zoom:50%;" />
 
@@ -46,10 +46,8 @@ We improved the style of pie chart of Mermaid dialog.
 - Improve Japanese translation by [ScratchBuild](https://github.com/ScratchBuild)
 - Improve Russian translation by [dragomano](https://github.com/dragomano)
 - Improve Swedish translation by [passar](https://github.com/passa)
-- Added swiss version of german by [Indeximal](https://github.com/Indeximal)
-<!-- 
+- Added swiss version of German by [Indeximal](https://github.com/Indeximal)
 - Added Persian translation by [sadra](https://github.com/sadra)
--->
 
 ### Others
 

--- a/_posts/2020-07-10-What's New-0.9.90.md
+++ b/_posts/2020-07-10-What's New-0.9.90.md
@@ -21,7 +21,7 @@ typora-copy-images-to: ../media/new-90
 
 - Support `id` attribute as link anchors.
 
-  Perviously Typora only support this kind of anchor links:
+  Previously Typora only support this kind of anchor links:
 
   ```markdown
   <a name="target-1"></a>anchor

--- a/_posts/2020-12-06-Typora on Windows.md
+++ b/_posts/2020-12-06-Typora on Windows.md
@@ -22,7 +22,7 @@ Typora supports [jump list](https://www.dummies.com/computers/operating-systems/
 
 If Typora is set as the default markdown editor, then in cmd.exe, then typing `.\example.md` or `start example.md` will open this markdown file.
 
-If you add `typora.exe` in `PATH`, you can also use `typora .` orr `typora example.md` to open current folder or target file in Typora.
+If you add `typora.exe` in `PATH`, you can also use `typora .` or `typora example.md` to open current folder or target file in Typora.
 
 You can find more details [here](https://support.typora.io/Use-Typora-From-Shell-or-cmd/).
 
@@ -59,7 +59,7 @@ You can also [add a shortcut key](https://support.typora.io/Shortcut-Keys/#windo
 
 Typora supports dark mode on Windows 10, you can simply choose a dark theme under dark mode.
 
-Or, you can set separate themes for light mode and dark mode. When the system’s color scheme changed, the corresponvsinf theme you chose will be applied.
+Or, you can set separate themes for light mode and dark mode. When the system’s color scheme changed, the corresponding theme you chose will be applied.
 
 <img src="/media/windows/Screenshot 2020-12-08 234125.png" alt="Screenshot 2020-12-08 234125" style="zoom:38%;" />
 

--- a/_posts/2020-12-06-Typora on macOS.md
+++ b/_posts/2020-12-06-Typora on macOS.md
@@ -114,9 +114,9 @@ Use your iPhone, iPad, or iPod touch to scan documents, draw sketch, or take a p
 
 You can use touch bar for context aware quick editing.
 
-![Screen Shot 2020-12-06 at 22.07.32](file:///Users/abner/Sites/typewiki/media/macOS/Screen Shot 2020-12-06 at 22.07.32.png?lastModify=1607354481)
+![Screen Shot 2020-12-06 at 22.07.32](/media/macOS/Screen Shot 2020-12-06 at 22.07.32.png?lastModify=1607354481)
 
-![Screen Shot 2020-12-06 at 22.08.21](file:///Users/abner/Sites/typewiki/media/macOS/Screen Shot 2020-12-06 at 22.08.21.png?lastModify=1607354481)
+![Screen Shot 2020-12-06 at 22.08.21](/media/macOS/Screen Shot 2020-12-06 at 22.08.21.png?lastModify=1607354481)
 
 <img src="/media/macOS/Screen Shot 2020-12-07 at 23.23.58.png" alt="Screen Shot 2020-12-07 at 23.23.58" />
 

--- a/_posts/2021-03-20-Typeset.md
+++ b/_posts/2021-03-20-Typeset.md
@@ -43,10 +43,10 @@ h1 {
 }
 ```
 
-You can partially make some text uppercased by inputing HTML directly in Typora:
+You can partially make some text uppercased by inputting HTML directly in Typora:
 
 ```html
-<span style="text-transform: uppercase;">This text will be in uppsercase</span>
+<span style="text-transform: uppercase;">This text will be in uppercase</span>
 ```
 
 #### Small-cap Headers
@@ -59,7 +59,7 @@ h4 {
 }
 ```
 
-You can partially make some text in small-caps by inputing HTML directly in Typora:
+You can partially make some text in small-caps by inputting HTML directly in Typora:
 
 ```html
 <span style="font-variant: small-caps;">This text will be in small-caps</span>
@@ -108,10 +108,10 @@ h4 {
 }
 ```
 
-You can partially make a paragraph with centered texts by inputing HTML directly in Typora:
+You can partially make a paragraph with centered texts by inputting HTML directly in Typora:
 
 ```html
-<center>Thsi text will be center aligned</center>
+<center>This text will be center aligned</center>
 ```
 
 #### Right to Left Writing

--- a/_posts/2021-04-20-Export.md
+++ b/_posts/2021-04-20-Export.md
@@ -112,7 +112,7 @@ If you want to export a HTML without styles, you should choose `Export `→ `HTM
 
 You can include outline in exported HTML by enable this option in `Export` →  `HTML` from preferences panel. 
 Whether it is collapsible outline or flat outline depends on your current setting. You can switch them under `View` menu or under `appearance` section in preferences panel.
-The css theme you use may affect the outline behavior in exported file, so please disable this option if the outline in exported file do not work well in some 3d party themes. 
+The css theme you use may affect the outline behavior in exported file, so please disable this option if the outline in exported file do not work well in some 3rd party themes. 
 
 #### Add Custom Contents
 
@@ -170,7 +170,7 @@ You could add your own css styles, contents, or javascript by configuring `Appen
 
 Typora provides image export option for feeds in social media, so by default is 640px width with 24px font size. But you can change this in preferences panel.
 
-Also, based on the purpose of this feature, overal performance, and the final size of output images, if the output article is too long, the image export would fail.
+Also, based on the purpose of this feature, overall performance and the final size of output images, if the output article is too long, the image export would fail.
 #### Theme
 
 You could choose another theme applied for exported images in preferences panel → Export → Image. By default, current theme will be used.

--- a/_posts/2021-07-12-What's New-0.11.md
+++ b/_posts/2021-07-12-What's New-0.11.md
@@ -137,7 +137,7 @@ typora-copy-images-to: ../media/new-11
 
 - Fix numbered math block size issue on exported PDF.
 
-- In previous versions, when inputing math, errors are thrown for unclosed braces, etc, and previous rendered math will be replaced by the error message, which makes it difficult to use Typora live for lecturing or giving talks. Now, errors are shown under previous correctly rendered math, making live lecturing for smoothly.
+- In previous versions, when inputting math, errors are thrown for unclosed braces, etc, and previous rendered math will be replaced by the error message, which makes it difficult to use Typora live for lecturing or giving talks. Now, errors are shown under previous correctly rendered math, making live lecturing go smoothly.
 
 - Compared to previous versions, following TeX Packages are supported:
 


### PR DESCRIPTION
Fixed typos in _posts up to initial release

Additional
- fixed wrong image url source names to point to the corresponding img/ folder file
- minor paragraph fixes

done manually and meticulously to avoid misreadings
conflicts with #61

Co-authored-by: SamJakob <SamJakob@users.noreply.github.com>

please review
if fit , could you add the hacktoberfest-accepted label ??