### PR TITLE
Fix a typo: ASSIC ↦ ASCII

### DIFF
--- a/_posts/new/2022-09-01-What's New-1.4.md
+++ b/_posts/new/2022-09-01-What's New-1.4.md
@@ -133,7 +133,7 @@ redirect_from: "What's-New-1.4/"
 
 ## Import / Export
 
-- PDF export now supports headers or footers contains non-ASSIC code when export.
+- PDF export now supports headers or footers contains non-ASCII code when export.
 - Improve image export quantity.
 - Fix PDF export not working on Windows when user account contains special characters.
 - Fix epub export show warnings in epub reader when contains video tag


### PR DESCRIPTION
There's a typo in [What's new 1.4 → Bug Fix → Import / Export](https://support.typora.io/What's-New-1.4/#Bug-fix):

> PDF export now supports headers or footers contains non-ASSIC code when export.

It should be “ASCII” (American Standard Code for Information Interchange).

https://github.com/typora/typora-issues/issues/4485

_Remark_: The Change Log within Typora (eg. `C:\Program Files\Typora\resources\Docs\Change Log.md`) also misspells it, but I've no idea where to fix that.