### PR TITLE
Fix(typo): The shortcut key of "Toggle DevTools" is "Shift + F12"

### DIFF
--- a/_posts/basic/2019-01-05-Shortcut Keys.md
+++ b/_posts/basic/2019-01-05-Shortcut Keys.md
@@ -110,7 +110,7 @@ On macOS, you can press `Esc` key to open inline preview for inline math, auto-c
 | Zoom In                         | Ctrl + Shift + =       | *(Not Supported)*     |
 | Zoom Out                        | Ctrl + Shift + -       | *(Not Supported)*     |
 | Switch Between Opened Documents | Ctrl + Tab             | Command + `           |
-| Toggle DevTools                 | Ctrl + Shift + I       | -                     |
+| Toggle DevTools                 | Shift + F12            | -                     |
 
 ## Change Shortcut Keys
 


### PR DESCRIPTION
Fix(typo): The shortcut key of "Toggle DevTools" is "Shift + F12", not "Ctrl + Shift + I".

"Ctrl + Shift + I" is the shortcut key for inserting images.