### PR TITLE
Fix "Recent folder" typo in 1.7 What's New

### DIFF
--- a/_posts/new/2023-09-01-What's New-1.7.md
+++ b/_posts/new/2023-09-01-What's New-1.7.md
@@ -11,7 +11,7 @@ redirect_from: "What's-New-1.7/"
 
 ## New & Improvements
 
-### Pinned and Rencent Folder
+### Pinned and Recent Folder
 
 When you open bottom menu on your files sidebar, you can now hover on recent folder item and click "pin" button to pin it. You can also click "Delete" button to delete a certain folder from your recent folder lists and also from File → Open Recent menu bar.
 


### PR DESCRIPTION
The 1.7 What's New post has a section "Pinned and Rencent Folder"; assuming it's meant to be "Pinned and Recent Folder".